### PR TITLE
DRM: Use correct DRM event context version

### DIFF
--- a/drm-howto/modeset-vsync.c
+++ b/drm-howto/modeset-vsync.c
@@ -559,7 +559,9 @@ static void modeset_draw(int fd)
 	FD_ZERO(&fds);
 	memset(&v, 0, sizeof(v));
 	memset(&ev, 0, sizeof(ev));
-	ev.version = DRM_EVENT_CONTEXT_VERSION;
+	/* Set this to only the latest version you support. Version 2
+	 * introduced the page_flip_handler, so we use that. */
+	ev.version = 2;
 	ev.page_flip_handler = modeset_page_flip_event;
 
 	/* redraw all outputs */


### PR DESCRIPTION
DRM_EVENT_CONTEXT_VERSION is the latest context version supported by
whatever version of libdrm is present. The HOWTO was blindly asserting
it supported whatever version that may be, even if it actually didn't.

With libdrm 2.4.78, setting a higher context version than 2 will attempt
to call the page_flip_handler2 vfunc if it was non-NULL, which being a
random chunk of stack memory, it might well have been.

Set the version as 2, which should be bumped only with the appropriate
version checks.

Signed-off-by: Daniel Stone <daniels@collabora.com>