### PR TITLE
Store index of currently connected encoder's CRTC

### DIFF
--- a/drm-howto/modeset-atomic.c
+++ b/drm-howto/modeset-atomic.c
@@ -284,6 +284,13 @@ static int modeset_find_crtc(int fd, drmModeRes *res, drmModeConnector *conn,
 			if (crtc > 0) {
 				drmModeFreeEncoder(enc);
 				out->crtc.id = crtc;
+				/* find the CRTC's index */
+				for (i = 0; i < res->count_crtcs; ++i) {
+					if (res->crtcs[i] == crtc) {
+						out->crtc_index = i;
+						break;
+					}
+				}
 				return 0;
 			}
 		}


### PR DESCRIPTION
Hello,

this commit fixes an issue where the CRTC's index wasn't stored when the currently connected encoder was used.

Thanks.